### PR TITLE
Fix double password hashing on signup

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -23,8 +23,7 @@ export const signup = async (req, res) => {
       return res.status(400).json({ message: 'User already exists' });
     }
 
-    const hashedPassword = await bcrypt.hash(password, 10);
-    const user = await User.create({ name, email, password: hashedPassword, role });
+    const user = await User.create({ name, email, password, role });
 
     const token = generateToken(user);
 


### PR DESCRIPTION
## Summary
- prevent double hashing of passwords during signup

## Testing
- `npm test` *(fails: Missing script)*
- `bun test` *(no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f4633b18c83289e5b3f50615e3699